### PR TITLE
配送先に関する実装

### DIFF
--- a/app/assets/javascripts/public/delivery_addresses.coffee
+++ b/app/assets/javascripts/public/delivery_addresses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/public/delivery_addresses.scss
+++ b/app/assets/stylesheets/public/delivery_addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/delivery_addresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,4 +1,7 @@
 class Public::CustomersController < ApplicationController
+  #ログインチェックを行う
+  before_action :ensure_correct_customer
+
   def show
   end
 
@@ -26,5 +29,14 @@ class Public::CustomersController < ApplicationController
     @customer.save
     #マイページに戻る
     redirect_to customers_mypage_path
+  end
+
+  private
+  def ensure_correct_customer
+    #current_customerが取得できない場合
+    if current_customer == nil
+      #ログイン画面に飛ばす
+      redirect_to new_customer_session_path
+    end
   end
 end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -23,12 +23,14 @@ class Public::CustomersController < ApplicationController
   end
 
   def withdraw
+    #ログイン中のユーザーを取得
     @customer = current_customer
-    #退会フラグをtrueにして保存
-    @customer.is_deleted = true
-    @customer.save
+    #退会フラグをtrueにして更新
+    @customer.update(is_deleted: true)
+    #セッション情報を削除する
+    reset_session
     #マイページに戻る
-    redirect_to customers_mypage_path
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/public/delivery_addresses_controller.rb
+++ b/app/controllers/public/delivery_addresses_controller.rb
@@ -1,0 +1,36 @@
+class Public::DeliveryAddressesController < ApplicationController
+  def index
+    @new_delivery_address = DeliveryAddress.new
+    @delivery_addresses = DeliveryAddress.all
+  end
+
+  def create
+    @delivery_addresses = DeliveryAddress.new(delivery_params)
+    @delivery_addresses.customer_id = current_customer.id
+    @delivery_addresses.save
+    redirect_back(fallback_location:root_path)
+  end
+
+  def edit
+    @delivery_address = DeliveryAddress.find(params[:id])
+  end
+
+  def update
+    @delivery_address = DeliveryAddress.find(params[:id])
+    @delivery_address.update(delivery_params)
+    redirect_to delivery_addresses_path
+  end
+
+  def destroy
+    @delivery_address = DeliveryAddress.find(params[:id])
+    @delivery_address.destroy
+    redirect_back(fallback_location:root_path)
+  end
+
+  private
+
+  def delivery_params
+    params.require(:delivery_address).permit(:post_code, :address, :name)
+  end
+
+end

--- a/app/controllers/public/delivery_addresses_controller.rb
+++ b/app/controllers/public/delivery_addresses_controller.rb
@@ -1,4 +1,7 @@
 class Public::DeliveryAddressesController < ApplicationController
+  #ログインチェックを行う
+  before_action :ensure_correct_customer
+  
   def index
     #新規登録用のインスタンス変数
     @new_delivery_address = DeliveryAddress.new
@@ -61,4 +64,11 @@ class Public::DeliveryAddressesController < ApplicationController
     params.require(:delivery_address).permit(:post_code, :address, :name)
   end
 
+  def ensure_correct_customer
+    #current_customerが取得できない場合
+    if current_customer == nil
+      #ログイン画面に飛ばす
+      redirect_to new_customer_session_path
+    end
+  end
 end

--- a/app/controllers/public/delivery_addresses_controller.rb
+++ b/app/controllers/public/delivery_addresses_controller.rb
@@ -1,34 +1,62 @@
 class Public::DeliveryAddressesController < ApplicationController
   def index
+    #新規登録用のインスタンス変数
     @new_delivery_address = DeliveryAddress.new
+    #登録されている配送先の取得
     @delivery_addresses = DeliveryAddress.all
   end
 
   def create
+    #POSTで受け取った配送先の情報をストロングパラメータを使って取得
     @delivery_addresses = DeliveryAddress.new(delivery_params)
+    #customer_idの値にcurrent_customer(ログイン中)のidを入れる
     @delivery_addresses.customer_id = current_customer.id
-    @delivery_addresses.save
-    redirect_back(fallback_location:root_path)
+    #取得した情報を元に保存
+    if @delivery_addresses.save
+      #保存できた場合は操作中の画面に戻る
+      redirect_back(fallback_location:root_path)
+    else
+      #保存できなかった場合は配送先テーブルを取得し、indexを表示する
+      @delivery_addresses = DeliveryAddress.all
+      render 'index'
+    end
   end
 
   def edit
+    #編集対象の配送先のidを元にテーブルからデータを取得する
     @delivery_address = DeliveryAddress.find(params[:id])
+    #取得したユーザーのidとログイン中のユーザーのidが一致しない場合
+    if @delivery_address.customer_id != current_customer.id
+      #トップページに移動する
+      redirect_to root_path
+    end
   end
 
   def update
+    #編集対象の配送先のidを元にテーブルからデータを取得する
     @delivery_address = DeliveryAddress.find(params[:id])
-    @delivery_address.update(delivery_params)
-    redirect_to delivery_addresses_path
+    #POSTで受け取った配送先の情報を更新する
+    if @delivery_address.update(delivery_params)
+      #更新できた場合は配送先一覧にリダイレクトする
+      redirect_to delivery_addresses_path
+    else
+      #更新できなかった場合は編集画面のままにしておく
+      render 'edit'
+    end
   end
 
   def destroy
+    #削除対象の配送先のidを元にテーブルからデータを取得する
     @delivery_address = DeliveryAddress.find(params[:id])
+    #対象データの削除を行う
     @delivery_address.destroy
+    #操作中の画面に戻る
     redirect_back(fallback_location:root_path)
   end
 
   private
 
+  #ストロングパラメータの設定
   def delivery_params
     params.require(:delivery_address).permit(:post_code, :address, :name)
   end

--- a/app/helpers/public/delivery_addresses_helper.rb
+++ b/app/helpers/public/delivery_addresses_helper.rb
@@ -1,0 +1,2 @@
+module Public::DeliveryAddressesHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,5 +3,9 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  #バリデーションの設定
+  validates :last_name, :first_name, :kana_last_name, :kana_first_name,
+            :post_code, :address, :telephone, presence: true
+  validates :email, uniqueness: true
   has_many :delivery_addresses
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,4 +3,5 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :delivery_addresses
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,5 +7,5 @@ class Customer < ApplicationRecord
   validates :last_name, :first_name, :kana_last_name, :kana_first_name,
             :post_code, :address, :telephone, presence: true
   validates :email, uniqueness: true
-  has_many :delivery_addresses
+  has_many :delivery_addresses, dependent: :destroy
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,0 +1,3 @@
+class DeliveryAddress < ApplicationRecord
+  belongs_to :customer
+end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,3 +1,6 @@
 class DeliveryAddress < ApplicationRecord
+  #バリデーションの追加(郵便番号、住所、宛名のないデータを登録できなくする。)
+  validates :post_code, :address, :name, presence: true
+  #外部キーの設定(カスタマーへ)
   belongs_to :customer
 end

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -33,5 +33,5 @@
   </tr>
       
 </table>
-<h3>配送先</h3>
-<h3>注文履歴</h3>
+<h3>配送先</h3><%= link_to '一覧を見る', delivery_addresses_path, class: ''%>
+<h3>注文履歴</h3><%= link_to '一覧を見る', '#', class: ''%>

--- a/app/views/public/delivery_addresses/edit.html.erb
+++ b/app/views/public/delivery_addresses/edit.html.erb
@@ -1,0 +1,22 @@
+<h2>配送先編集</h2>
+<%= form_with model:@delivery_address do |f| %>
+  <div>
+    <%= f.label :post_code %>
+    <%= f.text_field :post_code %>
+  </div>
+
+  <div>
+    <%= f.label :address %>
+    <%= f.text_field :address %>
+  </div>
+
+  <div>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+
+<% end %>

--- a/app/views/public/delivery_addresses/index.html.erb
+++ b/app/views/public/delivery_addresses/index.html.erb
@@ -38,8 +38,8 @@
         <td><%= delivery.address %></td>
         <td><%= delivery.name %></td>
         <td>
-          <%= link_to '編集する', edit_delivery_address_path(delivery) %>|
-          <%= link_to '削除する', delivery_address_path(delivery), method: :delete %>
+          <%= link_to '編集する', edit_delivery_address_path(delivery), class: "btn btn-sm btn-success edit_address_#{delivery.id}" %>|
+          <%= link_to '削除する', delivery_address_path(delivery), method: :delete, data: { confirm: 'この配送先を削除しますか？' }, class: "btn btn-sm btn-danger destroy_address_#{delivery.id}" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/public/delivery_addresses/index.html.erb
+++ b/app/views/public/delivery_addresses/index.html.erb
@@ -1,0 +1,47 @@
+
+<h2>配送先登録/一覧</h2>
+
+<%= form_with model:@new_delivery_address do |f| %>
+  <div class="field">
+    <%= f.label :post_code %>
+    <%= f.text_field :post_code %>
+  </div>
+
+  <div class="field">
+    <%= f.label :address %>
+    <%= f.text_field :address %>
+  </div>
+
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end%>
+
+<table>
+  <thead>
+    <tr>
+      <th>郵便番号</th>
+      <th>住所</th>
+      <th>宛名</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @delivery_addresses.each do |delivery| %>
+      <tr>
+        <td><%= delivery.post_code %></td>
+        <td><%= delivery.address %></td>
+        <td><%= delivery.name %></td>
+        <td>
+          <%= link_to '編集する', edit_delivery_address_path(delivery) %>|
+          <%= link_to '削除する', delivery_address_path(delivery), method: :delete %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     sessions: 'public/sessions',
     registrations: 'public/registrations'
   }
+  devise_scope :customer do
+    get '/customers', to: 'public/registrations#new'
+  end
   get 'customers/mypage' => 'public/customers#show'
   get 'customers/unsubscribe' => 'public/customers#unsubscribe'
   patch 'customers/withdraw' => 'public/customers#withdraw'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
   root to: 'public/homes#top'
   get '/about' => 'public/homes#about'
 
+  resources :delivery_addresses, module: :public, :except => [:new, :show]
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
 end

--- a/db/migrate/20220118114727_create_delivery_addresses.rb
+++ b/db/migrate/20220118114727_create_delivery_addresses.rb
@@ -1,0 +1,12 @@
+class CreateDeliveryAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :delivery_addresses do |t|
+      t.integer :customer_id,   null: false
+      t.string  :post_code,     null: false
+      t.string  :address,       null: false
+      t.string  :name,          null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_18_114727) do
+ActiveRecord::Schema.define(version: 2022_01_17_082059) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -54,15 +54,6 @@ ActiveRecord::Schema.define(version: 2022_01_18_114727) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
-  end
-
-  create_table "delivery_addresses", force: :cascade do |t|
-    t.integer "customer_id", null: false
-    t.string "post_code", null: false
-    t.string "address", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_082059) do
+ActiveRecord::Schema.define(version: 2022_01_18_114727) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -54,6 +54,15 @@ ActiveRecord::Schema.define(version: 2022_01_17_082059) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
+  end
+
+  create_table "delivery_addresses", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.string "post_code", null: false
+    t.string "address", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/test/controllers/public/delivery_addresses_controller_test.rb
+++ b/test/controllers/public/delivery_addresses_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Public::DeliveryAddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/delivery_addresses.yml
+++ b/test/fixtures/delivery_addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/delivery_address_test.rb
+++ b/test/models/delivery_address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeliveryAddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
配送先に関する実装が完了しました。
・配送先一覧画面
・配送先登録及び編集処理
・配送先のバリデーション
カスタマーページで以下の変更をおこなっています。
・バリデーションの一部変更
・退会処理後にセッション情報の削除、リダイレクト先の変更
配送先とカスタマーページ両方の変更点
・ログインチェック

ご確認お願いします。