### PR TITLE
Customer link fix

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -8,6 +8,7 @@ class Public::OrdersController < ApplicationController
 
   def new
     @order = Order.new
+    @address = DeliveryAddress.where(customer_id: current_customer)
   end
 
   def create

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -4,9 +4,9 @@ class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
   before_action :customer_state, only: [:create]
 
-  def after_sign_in_path_for(resource)#TODO-後ほど削除予定
-    customers_mypage_path
-  end
+  #def after_sign_in_path_for(resource)#TODO-後ほど削除予定
+  #  customers_mypage_path
+  #end
 
   # GET /resource/sign_in
   # def new

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,9 +56,8 @@
     <%= yield %>
   </main>
 
-  <footer>
-
-    <p class="copy">©︎NaganoCake</p>
+  <footer class='fixed-bottom'>
+      <p class="copy">©︎NaganoCake</p>
   
 
   </footer>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -40,7 +40,7 @@
   </table>
   <div class='d-flex justify-content-between'>
   <div>
-    <%= link_to '買い物を続ける', items_path, class:'btn btn-primary ml-5' %>
+    <%= link_to '買い物を続ける', root_path, class:'btn btn-primary ml-5' %>
   </div>
     <div class='row mr-1 border'>
     <p class='col-auto col-form-label border'>合計金額</p>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -50,6 +50,8 @@
     </div>
   </div>
   <div class='d-flex justify-content-center'>
-    <%= link_to '情報入力に進む', new_order_path, class:'btn btn-success text-center' %>
+    <% if @cart_items.presence %>
+      <%= link_to '情報入力に進む', new_order_path, class:'btn btn-success text-center' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -25,7 +25,7 @@
     <%= f.radio_button :select_address, 1 %>
     <%= f.label :select_address, '登録済み住所' %>
     <p>
-      <%= f.select :delivery_address_id, options_from_collection_for_select(DeliveryAddress.all, :id, :full_address) %>
+      <%= f.select :delivery_address_id, options_from_collection_for_select(@address, :id, :full_address) %>
     </p>
   </div>
   <div>


### PR DESCRIPTION
顧客側画面に関する修正を行いました。
・ログイン後にトップページへ
・カート画面の「買い物を続ける」を押すとトップページへ
・配送先の検索条件を追加
・カートに商品が入っている場合のみ情報入力用のボタンを表示
レイアウトの変更
・フッターをブラウザの最下部に来るようにクラス付け
