### PR TITLE
ぽむ[修正箇所]

### DIFF
--- a/app/assets/stylesheets/public/items.scss
+++ b/app/assets/stylesheets/public/items.scss
@@ -11,12 +11,6 @@
   margin-top:90px;
 }
 
-.form-group.row{
-  margin-top:90px;
-  display:flex;
-  justify-content:center;
-}
-
 .col.show{
   width:304px;
 }

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -20,7 +20,13 @@
            <td><%= customer.id %></td>
            <td><%= link_to customer.last_name + customer.first_name , admin_customer_path(customer) %></td>
            <td><%= customer.email %></td>
-           <td><%= customer.is_deleted %></td>
+           <td>
+            <% if customer.is_deleted == true %>
+             <p class="col-md-auto text-secondary font-weight-bold">退会</p>
+            <% else %>
+             <p class="col-md-auto text-success font-weight-bold">有効</p>
+            <% end %>
+           </td>
          </tr>
         <% end %>
 

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -38,7 +38,12 @@
 
   <div class='row'>
     <p class='col-md-2'>会員ステータス</p>
-    <p class="col-md-2 text-success font-weight-bold"><%= @customer.is_deleted %></p>
+      <% if @customer.is_deleted == true %>
+       <p class="col-md-2 text-secondary font-weight-bold">退会</p>
+      <% else %>
+       <p class="col-md-2 text-success font-weight-bold">有効</p>
+      <% end %>
+    </p>
   </div>
 
   <div class='row'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    
+
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
@@ -26,7 +26,7 @@
             <ul class="navbar-nav ml-auto">
               <% if admin_signed_in? %><!--adminでログインされている-->
                 <li><%= link_to '商品一覧' , admin_items_path, class: "btn btn-light" %></li>
-                <li><%= link_to '!会員一覧' , admin_customers_path, class: "btn btn-light" %></li>
+                <li><%= link_to '会員一覧' , admin_customers_path, class: "btn btn-light" %></li>
                 <li><%= link_to '注文履歴一覧' , admin_path, class: "btn btn-light" %></li>
                 <li><%= link_to 'ジャンル一覧' , admin_genres_path, class: "btn btn-light" %></li>
                 <li><%= link_to 'ログアウト' , destroy_admin_session_path, method: :delete, class: "btn btn-light" %></li>
@@ -34,7 +34,7 @@
                 <li class="welcome-text">ようこそ、<%= current_customer.last_name %>さん！</li>
                 <li><%= link_to 'マイページ' , customers_mypage_path, class: "btn btn-light" %></li>
                 <li><%= link_to '商品一覧' , items_path, class: "btn btn-light" %></li>
-                <li><%= link_to '!カート' , cart_items_path, class: "btn btn-light" %></li>
+                <li><%= link_to 'カート' , cart_items_path, class: "btn btn-light" %></li>
                 <li><%= link_to 'ログアウト' , destroy_customer_session_path, method: :delete, class: "btn btn-light" %></li>
               <% else %><!--ログインされていない-->
                 <li><%= link_to 'About' , about_path, class: "btn btn-light" %></li>
@@ -59,7 +59,7 @@
   <footer>
 
     <p class="copy">©︎NaganoCake</p>
-  
+
 
   </footer>
 

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -17,7 +17,7 @@
      <div class="col">
       <!--画像が表示されない-->
       <p><%= attachment_image_tag item, :image, :fill, 250, 125, format:'jpeg'%></p>
-      <p class="font-weight-bold"><%= item.name %></p>
+      <p class="font-weight-bold"><%= link_to item.name, item_path(item.id), class: "item_#{item.id}" %></p>
       <p class="font-weight-bold">¥<%= item.price %></p>
      </div>
     <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -15,8 +15,11 @@
   <div class="row mt-4">
     <% @items.each do |item| %>
      <div class="col">
-      <!--画像が表示されない-->
-      <p><%= attachment_image_tag item, :image, :fill, 250, 125, format:'jpeg'%></p>
+      <p>
+        <%= link_to item_path(item.id) do %>
+         <%= attachment_image_tag item, :image, :fill, 250, 125, format:'jpeg'%>
+        <% end %>
+      </p>
       <p class="font-weight-bold"><%= link_to item.name, item_path(item.id), class: "item_#{item.id}" %></p>
       <p class="font-weight-bold">¥<%= item.price %></p>
      </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,10 +1,10 @@
-<div class="container">
-  <div class='form-group row'>
-    <div class="col-5">
+<div class="container m-5">
+  <div class='row d-flex justify-content-center'>
+    <div class="col-auto">
       <%= attachment_image_tag @item,:image,:fill, 400, 230, format: 'jpeg' %>
     </div>
 
-    <div class='row'>
+    <div class='col-auto'>
       <table class="table table-borderless">
         <tbody>
           <tr>
@@ -32,7 +32,6 @@
           </tr>
         </tbody>
       </table>
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 行った編集箇所
- item/showのscssから問題になっていた記述を削除し、レイアウトの修正
- トップページの新着商品から直接商品詳細へ飛べるよう遷移先を指定
- トップページから詳細画像へ遷移するリンクを、商品名だけでなく、商品画像からも遷移できるようリンクを設定
- 管理者側の会員一覧で、会員ステータスが「false」「true」の表記になっていたため、「有効」「退会」と表記されるように変更
- ヘッダーメニューのカート、商品一覧の頭についていた「！」を削除